### PR TITLE
Added decline button

### DIFF
--- a/app/controller/requests.rb
+++ b/app/controller/requests.rb
@@ -5,10 +5,18 @@ class Bnb < Sinatra::Base
   end
 
   post '/requests' do
-    booking = Booking.get(params[:host_request_id])
-    booking.status = 'Confirmed'
-    booking.save
-    flash.keep[:notice] = "Space request confirmed :)"
-    redirect('/requests')
+    if  params[:confirmed]
+      booking = Booking.get(params[:host_request_id])
+      booking.status = 'Confirmed'
+      booking.save
+      flash.keep[:notice] = "Space request confirmed :)"
+      redirect('/requests')
+    else 
+      booking = Booking.get(params[:host_request_id])
+      booking.status = 'Declined'
+      booking.save
+      flash.keep[:notice] = "Space request was declined :("
+      redirect('/requests')
+    end
   end
 end

--- a/app/views/requests.erb
+++ b/app/views/requests.erb
@@ -1,17 +1,26 @@
 <h1>Requests</h1>
 <ul>
-  <% @host_requests.each do |host_requests| %>
-    <li>Property name:  <%= Space.get(host_requests.space_id).name %> </li>
-    <li>Guest info:  <%= User.get(host_requests.guest_id).name %> </li>
-    <li>Status:  <%= host_requests.status %> </li>
-    <li>Date requested:  <%= host_requests.date_requested %> </li>
-    <% unless host_requests.status == 'Confirmed' %>
-      <li>
-        <form action="/requests" method="post">
-          <input type="hidden" name="host_request_id" value="<%= host_requests.id %>">
-          <button type="submit" name="confirmed">Confirm</button>
-        </form>
-      </li>
+  <% @host_requests.each do |host_request| %>
+    <% if host_request.date_requested%>
+      <li>Property name:  <%= Space.get(host_request.space_id).name %> </li>
+      <li>Guest info:  <%= User.get(host_request.guest_id).name %> </li>
+      <li>Status:  <%= host_request.status %> </li>
+      <li>Date requested:  <%= host_request.date_requested %> </li>
+      <% unless (host_request.status == 'Confirmed') || (host_request.status == 'Declined') %>
+        <li>
+          <form action="/requests" method="post">
+            <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+            <button type="submit" name="confirmed" value="true">Confirm</button>
+          </form>
+        </li>
+
+        <li>
+          <form action="/requests" method="post">
+            <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+            <button type="submit" name="declined" value="false">Decline</button>
+          </form>
+        </li>
+      <% end %>
     <% end %>
   <% end %>
 </ul>

--- a/spec/features/request_dashboard_spec.rb
+++ b/spec/features/request_dashboard_spec.rb
@@ -15,45 +15,68 @@ feature 'Request Dashboard' do
     visit 'requests'
   end
 
-  scenario 'User should have a request dashboard' do
-    expect(page.status_code).to eq 200
-    expect(page).to have_content 'Requests'
-  end
+  feature 'Host' do
+    scenario 'should have a request dashboard' do
+      expect(page.status_code).to eq 200
+      expect(page).to have_content 'Requests'
+    end
 
-  scenario 'User should only see requests for their own spaces' do
-    expect(page).to have_content('BigBen')
-    expect(page).to have_content('Kyle')
-    expect(page).to have_content('Status: Pending')
-    expect(page).to have_content('Date requested: 2016-05-12')
-    expect(page).not_to have_content('The Rizz')
-    expect(page).not_to have_content('In paris. La vie!')
-  end
+    scenario 'should only see requests for their own spaces' do
+      expect(page).to have_content('BigBen')
+      expect(page).to have_content('Kyle')
+      expect(page).to have_content('Status: Pending')
+      expect(page).to have_content('Date requested: 2016-05-12')
+      expect(page).not_to have_content('The Rizz')
+      expect(page).not_to have_content('In paris. La vie!')
+    end
 
-  scenario 'User should receive new request on dashboard' do
-    expect(page).to have_content('BigBen')
-    expect(page).to have_content('Kyle')
-    expect(page).to have_content('Status: Pending')
-    expect(page).to have_content('Date requested: 2016-05-12')
-  end
+    scenario 'should receive new request on dashboard' do
+      expect(page).to have_content('BigBen')
+      expect(page).to have_content('Kyle')
+      expect(page).to have_content('Status: Pending')
+      expect(page).to have_content('Date requested: 2016-05-12')
+    end
 
-  scenario 'User can confirm guest request' do
-    expect(page).to have_button 'Confirm'
-  end
+    scenario 'can confirm guest request' do
+      expect(page).to have_button 'Confirm'
+    end
 
-  scenario 'User sees confirmation after clicking confirm' do
-    click_button 'Confirm'
-    expect(current_path).to eq '/requests'
-    expect(page).to have_content 'Space request confirmed :)'
-  end
+    scenario 'sees a confirmation flash after clicking confirm' do
+      click_button 'Confirm'
+      expect(current_path).to eq '/requests'
+      expect(page).to have_content 'Space request confirmed :)'
+    end    
 
-  scenario 'User changes status of booking request from pending to confirmed' do
-    click_button 'Confirm'
-    expect(page).to have_content 'Status: Confirmed'
-    expect(page).not_to have_content 'Status: Pending'
-  end
+    scenario 'changes status of booking request from pending to confirmed' do
+      click_button 'Confirm'
+      expect(page).to have_content 'Status: Confirmed'
+      expect(page).not_to have_content 'Status: Pending'
+    end
 
-  scenario 'User should not see confirm button once booking status is confirmed' do
-    click_button 'Confirm'
-    expect(page).not_to have_button 'Confirm'
+    scenario 'should not see confirm or decline button once booking status is confirmed' do
+      click_button 'Confirm'
+      expect(page).not_to have_button 'Confirm'
+    end
+
+    scenario 'can decline a guest request' do
+      expect(page).to have_button 'Decline'
+    end
+
+    scenario 'sees a declined flash after clicking decline' do
+      click_button 'Decline'
+      expect(current_path).to eq '/requests'
+      expect(page).to have_content 'Space request was declined :('
+    end
+
+    scenario 'changes status of booking request from pending to declined' do
+      click_button 'Decline'
+      expect(page).to have_content 'Status: Declined'
+      expect(page).not_to have_content 'Status: Pending'
+    end
+
+    scenario 'should not see confirm or decline button once booking status is confirmed' do
+      click_button 'Decline'
+      expect(page).not_to have_button 'Decline'
+    end
   end
 end


### PR DESCRIPTION
- Changed wording in request_dashboard_spec to clearify if referring to host or guest
- Duplicated the "confirm" button test to test the behaviour of decline button
- Solved bug: Booking requests are no longer displayed if a request_date is missing
