### PR TITLE
close #35 guest notification

### DIFF
--- a/app/controller/requests.rb
+++ b/app/controller/requests.rb
@@ -1,6 +1,7 @@
 class Bnb < Sinatra::Base
   get '/requests' do
     @host_requests = Booking.all(host_id: session[:user_id])
+    @guest_requests = Booking.all(guest_id: session[:user_id])
     erb :requests
   end
 
@@ -11,7 +12,7 @@ class Bnb < Sinatra::Base
       booking.save
       flash.keep[:notice] = "Space request confirmed :)"
       redirect('/requests')
-    else 
+    else
       booking = Booking.get(params[:host_request_id])
       booking.status = 'declined'
       booking.save

--- a/app/model/user.rb
+++ b/app/model/user.rb
@@ -27,7 +27,7 @@ class User
     end
 
     def self.authenticate(email, password)
-      user = first(:email)
+      user = first(email: email)
       if user && BCrypt::Password.new(user.password_hash) == password
         user
       else

--- a/app/views/_navbar.erb
+++ b/app/views/_navbar.erb
@@ -1,13 +1,17 @@
 <% if current_user %>
    Welcome <%= current_user.name %>
 
+    <form action='/spaces/new' method="get">
+        <button type="submit">Create space</button>
+    </form>
+
+    <form action='/requests'>
+      <button type="submit">Check requests</button>
+    </form>
+
     <form action='/session' method="post">
       <input type='hidden' name='_method' value='delete'>
       <button type="submit">Sign out</button>
-    </form>
-
-    <form action='/spaces/new' method="get">
-        <button type="submit" id="create_space">Create space</button>
     </form>
 
   <%else%>

--- a/app/views/requests.erb
+++ b/app/views/requests.erb
@@ -1,6 +1,17 @@
 <h1>Requests</h1>
 
 <h2>Requests I've made</h2>
+<ul>
+  <% @guest_requests.each do |guest_request| %>
+    <% if guest_request.date_requested%>
+      <li>Property name:  <%= Space.get(guest_request.space_id).name %> </li>
+      <li>Host info:  <%= User.get(guest_request.host_id).name %> </li>
+      <li>Status:  <%= guest_request.status.capitalize %> </li>
+      <li>Date requested:  <%= guest_request.date_requested %> </li>
+    <% end %>
+  <% end %>
+</ul>
+
 
 <h2>Requests I've received</h2>
 <ul>

--- a/app/views/requests.erb
+++ b/app/views/requests.erb
@@ -2,12 +2,16 @@
 
 <h2>Requests I've made</h2>
 <ul>
-  <% @guest_requests.each do |guest_request| %>
-    <% if guest_request.date_requested%>
-      <li>Property name:  <%= Space.get(guest_request.space_id).name %> </li>
-      <li>Host info:  <%= User.get(guest_request.host_id).name %> </li>
-      <li>Status:  <%= guest_request.status.capitalize %> </li>
-      <li>Date requested:  <%= guest_request.date_requested %> </li>
+  <% if @guest_requests.empty? %>
+    <li>It seems like you haven't made any request yet</li>
+  <% else %>
+    <% @guest_requests.each do |guest_request| %>
+      <% if guest_request.date_requested%>
+        <li>Property name:  <%= Space.get(guest_request.space_id).name %> </li>
+        <li>Host info:  <%= User.get(guest_request.host_id).name %> </li>
+        <li>Status:  <%= guest_request.status.capitalize %> </li>
+        <li>Date requested:  <%= guest_request.date_requested %> </li>
+      <% end %>
     <% end %>
   <% end %>
 </ul>
@@ -15,26 +19,30 @@
 
 <h2>Requests I've received</h2>
 <ul>
-  <% @host_requests.each do |host_request| %>
-    <% if host_request.date_requested%>
-      <li>Property name:  <%= Space.get(host_request.space_id).name %> </li>
-      <li>Guest info:  <%= User.get(host_request.guest_id).name %> </li>
-      <li>Status:  <%= host_request.status.capitalize %> </li>
-      <li>Date requested:  <%= host_request.date_requested %> </li>
-      <% unless (host_request.status == 'confirmed') || (host_request.status == 'declined') %>
-        <li>
-          <form action="/requests" method="post">
-            <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
-            <button type="submit" name="confirmed" value="true">Confirm</button>
-          </form>
-        </li>
+  <% if @host_requests.empty? %>
+    <li>It seems like you haven't received any request yet</li>
+  <% else %>
+    <% @host_requests.each do |host_request| %>
+      <% if host_request.date_requested%>
+        <li>Property name:  <%= Space.get(host_request.space_id).name %> </li>
+        <li>Guest info:  <%= User.get(host_request.guest_id).name %> </li>
+        <li>Status:  <%= host_request.status.capitalize %> </li>
+        <li>Date requested:  <%= host_request.date_requested %> </li>
+        <% unless (host_request.status == 'confirmed') || (host_request.status == 'declined') %>
+          <li>
+            <form action="/requests" method="post">
+              <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+              <button type="submit" name="confirmed" value="true">Confirm</button>
+            </form>
+          </li>
 
-        <li>
-          <form action="/requests" method="post">
-            <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
-            <button type="submit" name="declined" value="false">Decline</button>
-          </form>
-        </li>
+          <li>
+            <form action="/requests" method="post">
+              <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+              <button type="submit" name="declined" value="false">Decline</button>
+            </form>
+          </li>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/requests.erb
+++ b/app/views/requests.erb
@@ -1,4 +1,8 @@
 <h1>Requests</h1>
+
+<h2>Requests I've made</h2>
+
+<h2>Requests I've received</h2>
 <ul>
   <% @host_requests.each do |host_request| %>
     <% if host_request.date_requested%>

--- a/spec/features/add_space_spec.rb
+++ b/spec/features/add_space_spec.rb
@@ -12,7 +12,7 @@ feature 'Add space form:' do
   end
 
   scenario 'new space gets listed on the main page' do
-    click_button 'create_space'
+    click_button 'Create space'
     fill_in :space_name, with: name
     fill_in :space_description, with: description
     fill_in :space_price, with: price

--- a/spec/features/navbar_spec.rb
+++ b/spec/features/navbar_spec.rb
@@ -23,7 +23,15 @@ feature 'Navbar' do
   scenario 'Create space' do
     named_signup
     click_button 'Create space'
-    expect(current_path).to eq'/spaces/new'
+    expect(current_path).to eq '/spaces/new'
     expect(page).to have_content('New space')
   end
+
+  scenario 'Check requests' do
+    named_signup
+    click_button 'Check requests'
+    expect(current_path).to eq '/requests'
+    expect(page).to have_content 'Requests'
+  end
+
 end

--- a/spec/features/request_dashboard_spec.rb
+++ b/spec/features/request_dashboard_spec.rb
@@ -12,7 +12,7 @@ feature 'Request Dashboard' do
 
   feature 'Host' do
     before :each do
-      signin(host1.name,1234)
+      signin(host1.email,1234)
       visit('requests')
     end
 
@@ -82,7 +82,7 @@ feature 'Request Dashboard' do
 
   feature 'Guest' do
     before :each do
-      signin(guest1.name,1234)
+      signin(guest1.email,1234)
       visit('requests')
     end
 
@@ -93,7 +93,7 @@ feature 'Request Dashboard' do
 
     scenario 'should see their own requests' do
       expect(page).to have_content('BigBen')
-      expect(page).to have_content('Guest')
+      expect(page).to have_content('Host1')
       expect(page).to have_content('Status: Pending')
       expect(page).to have_content('Date requested: 2016-05-12')
     end

--- a/spec/features/request_dashboard_spec.rb
+++ b/spec/features/request_dashboard_spec.rb
@@ -1,29 +1,29 @@
 feature 'Request Dashboard' do
-  let(:guest) { User.create(name: 'Kyle', username: 'Kyle123', email: 'Kyle@me.com', password: 1234, password_confirmation: 1234) }
+  let(:guest1) { User.create(name: 'Guest', username: 'Guest123', email: 'guest1@me.com', password: 1234, password_confirmation: 1234) }
 
-  let(:host) { User.create(name: 'Anne', username: 'Anne', email: 'anne@me.com', password: 1234, password_confirmation: 1234) }
-  let(:host2) { User.create(name: 'Not Anne', username: 'Not Anne', email: 'not-anne@me.com', password: 1234, password_confirmation: 1234)}
+  let(:host1) { User.create(name: 'Host1', username: 'Host1', email: 'host1@me.com', password: 1234, password_confirmation: 1234) }
+  let(:host2) { User.create(name: 'Host2', username: 'Host2', email: 'host2@me.com', password: 1234, password_confirmation: 1234)}
 
-  let(:space) { Space.create(name: 'BigBen', description: 'Big bell in London', price: 250, user: host) }
+  let(:space1) { Space.create(name: 'BigBen', description: 'Big bell in London', price: 250, user: host1) }
   let(:space2) { Space.create(name: 'The Rizz', description: 'In paris. La vie!', price: 250, user: host2)}
 
-  let!(:booking) { Booking.create(space_id: space.id, host_id: host.id, guest_id: guest.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
-  let!(:booking2) { Booking.create(space_id: space2.id, host_id: host2.id, guest_id: guest.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
-
-  before :each do
-    signin('Anne',1234)
-    visit 'requests'
-  end
+  let!(:booking) { Booking.create(space_id: space1.id, host_id: host1.id, guest_id: guest1.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
+  let!(:booking2) { Booking.create(space_id: space2.id, host_id: host2.id, guest_id: guest1.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
 
   feature 'Host' do
-    scenario 'should have a request dashboard' do
+    before :each do
+      signin(host1.name,1234)
+      visit('requests')
+    end
+
+    scenario 'should have a "Requests I\'ve received"' do
       expect(page.status_code).to eq 200
-      expect(page).to have_content 'Requests'
+      expect(page).to have_content('Requests I\'ve received')
     end
 
     scenario 'should only see requests for their own spaces' do
       expect(page).to have_content('BigBen')
-      expect(page).to have_content('Kyle')
+      expect(page).to have_content('Guest')
       expect(page).to have_content('Status: Pending')
       expect(page).to have_content('Date requested: 2016-05-12')
       expect(page).not_to have_content('The Rizz')
@@ -32,7 +32,7 @@ feature 'Request Dashboard' do
 
     scenario 'should receive new request on dashboard' do
       expect(page).to have_content('BigBen')
-      expect(page).to have_content('Kyle')
+      expect(page).to have_content('Guest')
       expect(page).to have_content('Status: Pending')
       expect(page).to have_content('Date requested: 2016-05-12')
     end
@@ -45,7 +45,7 @@ feature 'Request Dashboard' do
       click_button 'Confirm'
       expect(current_path).to eq '/requests'
       expect(page).to have_content 'Space request confirmed :)'
-    end    
+    end
 
     scenario 'changes status of booking request from pending to confirmed' do
       click_button 'Confirm'
@@ -77,6 +77,25 @@ feature 'Request Dashboard' do
     scenario 'should not see confirm or decline button once booking status is confirmed' do
       click_button 'Decline'
       expect(page).not_to have_button 'Decline'
+    end
+  end
+
+  feature 'Guest' do
+    before :each do
+      signin(guest1.name,1234)
+      visit('requests')
+    end
+
+    scenario 'should have a "Requests I\'ve made"' do
+      expect(page.status_code).to eq 200
+      expect(page).to have_content 'Requests I\'ve made'
+    end
+
+    scenario 'should see their own requests' do
+      expect(page).to have_content('BigBen')
+      expect(page).to have_content('Guest')
+      expect(page).to have_content('Status: Pending')
+      expect(page).to have_content('Date requested: 2016-05-12')
     end
   end
 end

--- a/spec/features/request_dashboard_spec.rb
+++ b/spec/features/request_dashboard_spec.rb
@@ -1,5 +1,6 @@
 feature 'Request Dashboard' do
   let(:guest1) { User.create(name: 'Guest', username: 'Guest123', email: 'guest1@me.com', password: 1234, password_confirmation: 1234) }
+  let(:guest2) { User.create(name: 'Guest2', username: 'Guest2123', email: 'guest2@me.com', password: 1234, password_confirmation: 1234) }
 
   let(:host1) { User.create(name: 'Host1', username: 'Host1', email: 'host1@me.com', password: 1234, password_confirmation: 1234) }
   let(:host2) { User.create(name: 'Host2', username: 'Host2', email: 'host2@me.com', password: 1234, password_confirmation: 1234)}
@@ -8,7 +9,7 @@ feature 'Request Dashboard' do
   let(:space2) { Space.create(name: 'The Rizz', description: 'In paris. La vie!', price: 250, user: host2)}
 
   let!(:booking) { Booking.create(space_id: space1.id, host_id: host1.id, guest_id: guest1.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
-  let!(:booking2) { Booking.create(space_id: space2.id, host_id: host2.id, guest_id: guest1.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
+  let!(:booking2) { Booking.create(space_id: space2.id, host_id: host2.id, guest_id: guest2.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
 
   feature 'Host' do
     before :each do

--- a/spec/features/request_dashboard_spec.rb
+++ b/spec/features/request_dashboard_spec.rb
@@ -3,13 +3,14 @@ feature 'Request Dashboard' do
   let(:guest2) { User.create(name: 'Guest2', username: 'Guest2123', email: 'guest2@me.com', password: 1234, password_confirmation: 1234) }
 
   let(:host1) { User.create(name: 'Host1', username: 'Host1', email: 'host1@me.com', password: 1234, password_confirmation: 1234) }
-  let(:host2) { User.create(name: 'Host2', username: 'Host2', email: 'host2@me.com', password: 1234, password_confirmation: 1234)}
+  let(:host2) { User.create(name: 'Host2', username: 'Host2', email: 'host2@me.com', password: 1234, password_confirmation: 1234) }
+  let(:host3) { User.create(name: 'Host3', username: 'Host3', email: 'host3@me.com', password: 1234, password_confirmation: 1234) }
 
   let(:space1) { Space.create(name: 'BigBen', description: 'Big bell in London', price: 250, user: host1) }
-  let(:space2) { Space.create(name: 'The Rizz', description: 'In paris. La vie!', price: 250, user: host2)}
+  let(:space2) { Space.create(name: 'The Rizz', description: 'In paris. La vie!', price: 250, user: host2) }
 
   let!(:booking) { Booking.create(space_id: space1.id, host_id: host1.id, guest_id: guest1.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
-  let!(:booking2) { Booking.create(space_id: space2.id, host_id: host2.id, guest_id: guest2.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
+  let!(:booking2) { Booking.create(space_id: space2.id, host_id: host2.id, guest_id: guest1.id, status: 'Pending', date_requested: '12/05/2016', total_price: 250) }
 
   feature 'Host' do
     before :each do
@@ -79,6 +80,13 @@ feature 'Request Dashboard' do
       click_button 'Decline'
       expect(page).not_to have_button 'Decline'
     end
+
+    scenario 'should display message if no requests have been received' do
+      click_button "Sign out"
+      signin(host3.email,1234)
+      visit('requests')
+      expect(page).to have_content('It seems like you haven\'t received any request yet')
+    end
   end
 
   feature 'Guest' do
@@ -98,5 +106,13 @@ feature 'Request Dashboard' do
       expect(page).to have_content('Status: Pending')
       expect(page).to have_content('Date requested: 2016-05-12')
     end
+
+    scenario 'should display message if no requests have been made' do
+      click_button "Sign out"
+      signin(guest2.email,1234)
+      visit('requests')
+      expect(page).to have_content('It seems like you haven\'t made any request yet')
+    end
+
   end
 end


### PR DESCRIPTION
- Fixed bug in User#authenticate: a login attempt would always try to log in to the first user in the DB listing.
- Users can see both incoming and outgoing booking requests on the same page
- Added button to navbar to be able to access the request page
- Added warning to the requests page to let users know if there is no incoming or outgoing booking request.
