### PR TITLE
fix visualization bug on requests page

### DIFF
--- a/app/controller/requests.rb
+++ b/app/controller/requests.rb
@@ -1,7 +1,7 @@
 class Bnb < Sinatra::Base
   get '/requests' do
-    puts @host_requests = Booking.all(host_id: session[:user_id])
-    puts @guest_requests = Booking.all(guest_id: session[:user_id])
+    @host_requests = Booking.all(host_id: session[:user_id])
+    @guest_requests = Booking.all(guest_id: session[:user_id])
     erb(:'/requests/index')
   end
 

--- a/app/controller/requests.rb
+++ b/app/controller/requests.rb
@@ -1,7 +1,7 @@
 class Bnb < Sinatra::Base
   get '/requests' do
-    @host_requests = Booking.all(host_id: session[:user_id])
-    @guest_requests = Booking.all(guest_id: session[:user_id])
+    puts @host_requests = Booking.all(host_id: session[:user_id])
+    puts @guest_requests = Booking.all(guest_id: session[:user_id])
     erb(:'/requests/index')
   end
 

--- a/app/views/requests/index.erb
+++ b/app/views/requests/index.erb
@@ -3,27 +3,29 @@
 <div class="flexbox">
   <section class="boxitem">
     <h2>Requests I've made</h2>
-      <% if @guest_requests.empty? %>
+      <% if @guest_requests.none? {|guest_request| guest_request.booking_start && guest_request.booking_end} %>
         <ul>
           <li>It seems like you haven't made any request yet</li>
         </ul>
       <% else %>
         <% @guest_requests.each do |guest_request| %>
-          <ul class="request">
+
             <% if guest_request.booking_start && guest_request.booking_end %>
+            <ul class="request">
               <li><strong>Property</strong> <%= Space.get(guest_request.space_id).name %> </li>
               <li><strong>Host</strong> <%= User.get(guest_request.host_id).name %> </li>
               <li><strong>Status</strong> <%= guest_request.status.capitalize %> </li>
               <li><strong>From</strong>  <%= guest_request.booking_start %> <strong>to</strong> <%= guest_request.booking_end %> </li>
+            </ul>
             <% end %>
-          </ul>
+
         <% end %>
       <% end %>
   </section>
 
   <section class="boxitem">
     <h2>Requests I've received</h2>
-      <% if @host_requests.empty? %>
+      <% if @host_requests.none? {|host_request| host_request.booking_start && host_request.booking_end} %>
         <ul>
           <li>It seems like you haven't received any request yet</li>
         </ul>


### PR DESCRIPTION
- Messages: "It seems like you haven't made any request yet" and "It seems like you haven't received any request yet" were only showing up if the booking db was empty, disappearing when new requests were left incomplete
- some tags in requests/index.erb where outside the conditional block, leading to new (empty) block creation for unfinished requests
