### PR TITLE
Close #57 individual request page

### DIFF
--- a/app/controller/bookings.rb
+++ b/app/controller/bookings.rb
@@ -14,7 +14,7 @@ class Bnb < Sinatra::Base
   end
 
   post '/bookings/new' do
-
+    redirect '/' unless session[:user_id]
     host_id = Space.get(params[:space_id]).user.id
     guest_id = User.get(session[:user_id]).id
     booking = Booking.create(space_id: params[:space_id],
@@ -29,6 +29,7 @@ class Bnb < Sinatra::Base
   end
 
   post '/bookings' do
+    redirect '/' unless session[:user_id]
     booking = Booking.get(session[:booking_id])
     booking_price_per_night = Space.get(booking.space_id).price
     start_date = Date.parse(params[:booking_start])
@@ -42,6 +43,7 @@ class Bnb < Sinatra::Base
   end
 
   get '/bookings/:id' do
+    redirect '/' unless session[:user_id]
     @booking = Booking.get(params[:id])
     erb :'bookings/detailed'
   end

--- a/app/controller/bookings.rb
+++ b/app/controller/bookings.rb
@@ -40,4 +40,9 @@ class Bnb < Sinatra::Base
     flash.keep[:notice] = "Request sent"
     redirect '/'
   end
+
+  get '/bookings/:id' do
+    @booking = Booking.get(params[:id])
+    erb :'bookings/detailed'
+  end
 end

--- a/app/controller/requests.rb
+++ b/app/controller/requests.rb
@@ -1,11 +1,13 @@
 class Bnb < Sinatra::Base
   get '/requests' do
+    redirect '/' unless session[:user_id]
     @host_requests = Booking.all(host_id: session[:user_id])
     @guest_requests = Booking.all(guest_id: session[:user_id])
     erb(:'/requests/index')
   end
 
   post '/requests' do
+    redirect '/' unless session[:user_id]
     if  params[:confirmed]
       booking = Booking.get(params[:host_request_id])
       booking.status = 'confirmed'

--- a/app/controller/spaces.rb
+++ b/app/controller/spaces.rb
@@ -9,7 +9,7 @@ class Bnb < Sinatra::Base
     else
       @filter_range = nil
     end
-    
+
     @spaces = Space.all
     @bookings = Booking.all
     erb :'/spaces/index'
@@ -20,6 +20,7 @@ class Bnb < Sinatra::Base
   end
 
   post '/spaces/new' do
+    redirect '/' unless session[:user_id]
     start_date = Date.parse(params[:start_availability])
     end_date = Date.parse(params[:end_availability])
     space = Space.new(name: params[:space_name],

--- a/app/public/main.css
+++ b/app/public/main.css
@@ -202,6 +202,11 @@ label {
   float: right;
 }
 
+#request-info {
+  text-align: center;
+  margin: 20px;
+}
+
 .other-requests .request {
   display: inline-block;
   margin: 20px;

--- a/app/public/main.css
+++ b/app/public/main.css
@@ -169,7 +169,8 @@ label {
 .flexbox {
   display: flex;
   justify-content: center;
-
+  background-color: rgb(218, 229, 251);
+  box-shadow: 3px 3px 10px 0px rgba(0,0,0,0.41)
 }
 
 .inline {
@@ -177,25 +178,38 @@ label {
 }
 
 .boxitem {
-  margin-top: 10px;
   width: 50%;
   padding: 25px;
 }
 
 .request {
   padding: 20px;
-  margin: 0 0 10px 0;
+  margin: 10px 0 10px 0;
   background-color: rgb(255, 255, 255);
   border-radius: .3em;
+  box-shadow: 3px 3px 10px 0px rgba(0,0,0,0.41);
+  display: block;
 }
 
 .request li {
-  font-size: 1.5em;
   line-height: 150%;
   display: inline-block;
 }
 
+.glyphicon-chevron-right {
+  font-size: 45px;
+  line-height: 120px;
+  float: right;
+}
 
+.other-requests .request {
+  display: inline-block;
+  margin: 20px;
+}
+
+.other-requests .request li {
+  width: 50%;
+}
 
 /*---------- CALENDAR ------------*/
 

--- a/app/public/main.css
+++ b/app/public/main.css
@@ -196,7 +196,7 @@ label {
   display: inline-block;
 }
 
-.glyphicon-chevron-right {
+a .glyphicon-chevron-right {
   font-size: 45px;
   line-height: 120px;
   float: right;

--- a/app/views/bookings/detailed.erb
+++ b/app/views/bookings/detailed.erb
@@ -3,6 +3,16 @@
 <div id="request-info">
   <p>From: <%= User.get(@booking.guest_id).email %></p><br>
   <p>Dates: <%= @booking.booking_start.strftime("%d/%m/%Y") %> to <%= @booking.booking_end.strftime("%d/%m/%Y") %></p><br>
+  <% unless (@booking.status == 'confirmed') || (@booking.status == 'declined') %>
+    <form class="inline" action="/requests" method="post">
+      <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
+      <button class="btn" type="submit" name="confirmed" value="true">Confirm Request from <%= User.get(@booking.guest_id).email %></button>
+    </form><br>
+    <form class="inline" action="/requests" method="post">
+      <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
+      <button class="btn" type="submit" name="declined" value="false">Decline Request from <%= User.get(@booking.guest_id).email %></button>
+    </form><br>
+  <% end %>
 </div>
 
 <div class="other-requests">
@@ -13,7 +23,6 @@
         <% if booking.booking_start && booking.id != @booking.id %>
           <ul class="request pull-left">
             <li>
-              <p><%= booking.id %></p><br>
               <p><%= Space.get(booking.space_id).name %></p><br>
               <p><%= booking.status.capitalize%></p><br>
               <p>Dates: <%= booking.booking_start.strftime("%d/%m/%Y") %> to <%= booking.booking_end.strftime("%d/%m/%Y") %></p><br>

--- a/app/views/bookings/detailed.erb
+++ b/app/views/bookings/detailed.erb
@@ -1,36 +1,40 @@
-<h1>Request for '<%= Space.get(@booking.space_id).name %>'</h1>
+<% if session[:user_id] == @booking.host_id %>
+  <h1>Request for '<%= Space.get(@booking.space_id).name %>'</h1>
 
-<div id="request-info">
-  <p>From: <%= User.get(@booking.guest_id).email %></p><br>
-  <p>Dates: <%= @booking.booking_start.strftime("%d/%m/%Y") %> to <%= @booking.booking_end.strftime("%d/%m/%Y") %></p><br>
-  <% unless (@booking.status == 'confirmed') || (@booking.status == 'declined') %>
-    <form class="inline" action="/requests" method="post">
-      <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
-      <button class="btn" type="submit" name="confirmed" value="true">Confirm Request from <%= User.get(@booking.guest_id).email %></button>
-    </form><br>
-    <form class="inline" action="/requests" method="post">
-      <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
-      <button class="btn" type="submit" name="declined" value="false">Decline Request from <%= User.get(@booking.guest_id).email %></button>
-    </form><br>
-  <% end %>
-</div>
-
-<div class="other-requests">
-  <h2>Other Requests for this Space</h2>
-  <div class="flexbox">
-    <section class="box-item">
-      <% Space.get(@booking.space_id).bookings.each do |booking| %>
-        <% if booking.booking_start && booking.id != @booking.id %>
-          <ul class="request pull-left">
-            <li>
-              <p><%= Space.get(booking.space_id).name %></p><br>
-              <p><%= booking.status.capitalize%></p><br>
-              <p>Dates: <%= booking.booking_start.strftime("%d/%m/%Y") %> to <%= booking.booking_end.strftime("%d/%m/%Y") %></p><br>
-            </li>
-            <a class="detailed-view" href="/bookings/<%= booking.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
-          </ul>
-        <% end %>
-      <% end %>
-    </section>
+  <div id="request-info">
+    <p>From: <%= User.get(@booking.guest_id).email %></p><br>
+    <p>Dates: <%= @booking.booking_start.strftime("%d/%m/%Y") %> to <%= @booking.booking_end.strftime("%d/%m/%Y") %></p><br>
+    <% unless (@booking.status == 'confirmed') || (@booking.status == 'declined') %>
+      <form class="inline" action="/requests" method="post">
+        <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
+        <button class="btn" type="submit" name="confirmed" value="true">Confirm Request from <%= User.get(@booking.guest_id).email %></button>
+      </form><br>
+      <form class="inline" action="/requests" method="post">
+        <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
+        <button class="btn" type="submit" name="declined" value="false">Decline Request from <%= User.get(@booking.guest_id).email %></button>
+      </form><br>
+    <% end %>
   </div>
-</div>
+
+  <div class="other-requests">
+    <h2>Other Requests for this Space</h2>
+    <div class="flexbox">
+      <section class="box-item">
+        <% Space.get(@booking.space_id).bookings.each do |booking| %>
+          <% if booking.booking_start && booking.id != @booking.id %>
+            <ul class="request pull-left">
+              <li>
+                <p><%= Space.get(booking.space_id).name %></p><br>
+                <p><%= booking.status.capitalize%></p><br>
+                <p>Dates: <%= booking.booking_start.strftime("%d/%m/%Y") %> to <%= booking.booking_end.strftime("%d/%m/%Y") %></p><br>
+              </li>
+              <a class="detailed-view" href="/bookings/<%= booking.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
+            </ul>
+          <% end %>
+        <% end %>
+      </section>
+    </div>
+  </div>
+<% else %>
+  <% redirect '/' %>
+<% end %>

--- a/app/views/bookings/detailed.erb
+++ b/app/views/bookings/detailed.erb
@@ -1,0 +1,27 @@
+<h1>Request for '<%= Space.get(@booking.space_id).name %>'</h1>
+
+<div id="request-info">
+  <p>From: <%= User.get(@booking.guest_id).email %></p><br>
+  <p>Dates: <%= @booking.booking_start.strftime("%d/%m/%Y") %> to <%= @booking.booking_end.strftime("%d/%m/%Y") %></p><br>
+</div>
+
+<div class="other-requests">
+  <h2>Other Requests for this Space</h2>
+  <div class="flexbox">
+    <section class="box-item">
+      <% Space.get(@booking.space_id).bookings.each do |booking| %>
+        <% if booking.booking_start && booking.id != @booking.id %>
+          <ul class="request pull-left">
+            <li>
+              <p><%= booking.id %></p><br>
+              <p><%= Space.get(booking.space_id).name %></p><br>
+              <p><%= booking.status.capitalize%></p><br>
+              <p>Dates: <%= booking.booking_start.strftime("%d/%m/%Y") %> to <%= booking.booking_end.strftime("%d/%m/%Y") %></p><br>
+            </li>
+            <a class="detailed-view" href="/bookings/<%= booking.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
+          </ul>
+        <% end %>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/views/bookings/detailed.erb
+++ b/app/views/bookings/detailed.erb
@@ -1,40 +1,43 @@
-<% if session[:user_id] == @booking.host_id %>
+<% if session[:user_id] == @booking.host_id || @booking.guest_id %>
   <h1>Request for '<%= Space.get(@booking.space_id).name %>'</h1>
 
   <div id="request-info">
     <p>From: <%= User.get(@booking.guest_id).email %></p><br>
     <p>Dates: <%= @booking.booking_start.strftime("%d/%m/%Y") %> to <%= @booking.booking_end.strftime("%d/%m/%Y") %></p><br>
-    <% unless (@booking.status == 'confirmed') || (@booking.status == 'declined') %>
-      <form class="inline" action="/requests" method="post">
-        <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
-        <button class="btn" type="submit" name="confirmed" value="true">Confirm Request from <%= User.get(@booking.guest_id).email %></button>
-      </form><br>
-      <form class="inline" action="/requests" method="post">
-        <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
-        <button class="btn" type="submit" name="declined" value="false">Decline Request from <%= User.get(@booking.guest_id).email %></button>
-      </form><br>
-    <% end %>
-  </div>
+    <% if session[:user_id] == @booking.host_id %>
 
-  <div class="other-requests">
-    <h2>Other Requests for this Space</h2>
-    <div class="flexbox">
-      <section class="box-item">
-        <% Space.get(@booking.space_id).bookings.each do |booking| %>
-          <% if booking.booking_start && booking.id != @booking.id %>
-            <ul class="request pull-left">
-              <li>
-                <p><%= Space.get(booking.space_id).name %></p><br>
-                <p><%= booking.status.capitalize%></p><br>
-                <p>Dates: <%= booking.booking_start.strftime("%d/%m/%Y") %> to <%= booking.booking_end.strftime("%d/%m/%Y") %></p><br>
-              </li>
-              <a class="detailed-view" href="/bookings/<%= booking.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
-            </ul>
-          <% end %>
-        <% end %>
-      </section>
+      <% unless (@booking.status == 'confirmed') || (@booking.status == 'declined') %>
+        <form class="inline" action="/requests" method="post">
+          <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
+          <button class="btn" type="submit" name="confirmed" value="true">Confirm Request from <%= User.get(@booking.guest_id).email %></button>
+        </form><br>
+        <form class="inline" action="/requests" method="post">
+          <input type="hidden" name="host_request_id" value="<%= @booking.id %>">
+          <button class="btn" type="submit" name="declined" value="false">Decline Request from <%= User.get(@booking.guest_id).email %></button>
+        </form><br>
+      <% end %>
     </div>
-  </div>
+
+    <div class="other-requests">
+      <h2>Other Requests for this Space</h2>
+      <div class="flexbox">
+        <section class="box-item">
+          <% Space.get(@booking.space_id).bookings.each do |booking| %>
+            <% if booking.booking_start && booking.id != @booking.id %>
+              <ul class="request pull-left">
+                <li>
+                  <p><%= Space.get(booking.space_id).name %></p><br>
+                  <p><%= booking.status.capitalize%></p><br>
+                  <p>Dates: <%= booking.booking_start.strftime("%d/%m/%Y") %> to <%= booking.booking_end.strftime("%d/%m/%Y") %></p><br>
+                </li>
+                <a class="detailed-view" href="/bookings/<%= booking.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
+              </ul>
+            <% end %>
+          <% end %>
+        </section>
+      </div>
+    </div>
+  <% end %>
 <% else %>
   <% redirect '/' %>
 <% end %>

--- a/app/views/bookings/new.erb
+++ b/app/views/bookings/new.erb
@@ -1,15 +1,19 @@
-<h1>Please select a date for your booking.</h1>
+<% if session[:user_id] %>
+  <h1>Please select a date for your booking.</h1>
 
-<form action="/bookings" method="post">
-  <input id="booking_start" type="hidden" name="booking_start">
-  <input id="booking_end" type="hidden" name="booking_end">
-  <div id="reportrange">
-      <i class="glyphicon glyphicon-calendar fa fa-calendar"></i>&nbsp;
-      <span></span> <b class="caret"></b>
-  </div>
-  <button class="btn" type="submit">Submit Request</button>
-</form>
+  <form action="/bookings" method="post">
+    <input id="booking_start" type="hidden" name="booking_start">
+    <input id="booking_end" type="hidden" name="booking_end">
+    <div id="reportrange">
+        <i class="glyphicon glyphicon-calendar fa fa-calendar"></i>&nbsp;
+        <span></span> <b class="caret"></b>
+    </div>
+    <button class="btn" type="submit">Submit Request</button>
+  </form>
 
-<script>
-  var booked_dates = <%= @booked_dates = @booked_dates.flatten.map { |date| date.strftime("%Y-%m-%d") } %>
-</script>
+  <script>
+    var booked_dates = <%= @booked_dates = @booked_dates.flatten.map { |date| date.strftime("%Y-%m-%d") } %>
+  </script>
+<% else %>
+  <% redirect '/' %>
+<% end %>

--- a/app/views/requests/index.erb
+++ b/app/views/requests/index.erb
@@ -44,17 +44,17 @@
               </li>
                 <a class="detailed-view" href="/bookings/<%= host_request.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
                 <li>
-                <% unless (host_request.status == 'confirmed') || (host_request.status == 'declined') %>
-                  <form class="inline" action="/requests" method="post">
-                    <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
-                    <button class="btn" type="submit" name="confirmed" value="true">Confirm</button>
-                  </form>
-                  <form class="inline" action="/requests" method="post">
-                    <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
-                    <button class="btn" type="submit" name="declined" value="false">Decline</button>
-                  </form><br>
+                  <% unless (host_request.status == 'confirmed') || (host_request.status == 'declined') %>
+                    <form class="inline" action="/requests" method="post">
+                      <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+                      <button class="btn" type="submit" name="confirmed" value="true">Confirm</button>
+                    </form>
+                    <form class="inline" action="/requests" method="post">
+                      <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+                      <button class="btn" type="submit" name="declined" value="false">Decline</button>
+                    </form><br>
+                  <% end %>
                 </li>
-              <% end %>
             </ul>
         <% end %>
       <% end %>

--- a/app/views/requests/index.erb
+++ b/app/views/requests/index.erb
@@ -13,11 +13,12 @@
             <% if guest_request.booking_start && guest_request.booking_end %>
             <ul class="request">
               <li>
-                <strong>Property</strong> <%= Space.get(guest_request.space_id).name %><br>
-                <strong>Host</strong> <%= User.get(guest_request.host_id).name %><br>
-                <strong>Status</strong> <%= guest_request.status.capitalize %><br>
-                <strong>From</strong>  <%= guest_request.booking_start %> <strong>to</strong> <%= guest_request.booking_end %><br>
+                <p><strong>Property</strong> <%= Space.get(guest_request.space_id).name %></p><br>
+                <p><strong>Host</strong> <%= User.get(guest_request.host_id).name %></p><br>
+                <p><strong>Status</strong> <%= guest_request.status.capitalize %></p><br>
+                <p><strong>From</strong>  <%= guest_request.booking_start %> <strong>to</strong> <%= guest_request.booking_end %><p><br>
               </li>
+              <a class="detailed-view" href="/bookings/<%= guest_request.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
             </ul>
             <% end %>
 
@@ -36,21 +37,23 @@
           <% if host_request.booking_start && host_request.booking_end %>
             <ul class="request">
               <li>
-                <strong>Property</strong> <%= Space.get(host_request.space_id).name %><br>
-                <strong>Guest</strong> <%= User.get(host_request.guest_id).name %><br>
-                <strong>Status</strong> <%= host_request.status.capitalize %><br>
-                <strong>From</strong> <%= host_request.booking_start %> <strong>to</strong> <%= host_request.booking_end %><br>
-              <% unless (host_request.status == 'confirmed') || (host_request.status == 'declined') %>
-                <form class="inline" action="/requests" method="post">
-                  <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
-                  <button class="btn" type="submit" name="confirmed" value="true">Confirm</button>
-                </form>
-                <form class="inline" action="/requests" method="post">
-                  <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
-                  <button class="btn" type="submit" name="declined" value="false">Decline</button>
-                </form><br>
-                </li>
+                <p><strong>Property</strong> <%= Space.get(host_request.space_id).name %></p><br>
+                <p><strong>Guest</strong> <%= User.get(host_request.guest_id).name %></p><br>
+                <p><strong>Status</strong> <%= host_request.status.capitalize %></p><br>
+                <p><strong>From</strong> <%= host_request.booking_start %> <strong>to</strong> <%= host_request.booking_end %></p><br>
               </li>
+                <a class="detailed-view" href="/bookings/<%= host_request.id %>"><i class="glyphicon glyphicon-chevron-right"></i></a>
+                <li>
+                <% unless (host_request.status == 'confirmed') || (host_request.status == 'declined') %>
+                  <form class="inline" action="/requests" method="post">
+                    <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+                    <button class="btn" type="submit" name="confirmed" value="true">Confirm</button>
+                  </form>
+                  <form class="inline" action="/requests" method="post">
+                    <input type="hidden" name="host_request_id" value="<%= host_request.id %>">
+                    <button class="btn" type="submit" name="declined" value="false">Decline</button>
+                  </form><br>
+                </li>
               <% end %>
             </ul>
         <% end %>

--- a/app/views/spaces/new.erb
+++ b/app/views/spaces/new.erb
@@ -22,12 +22,12 @@
 
     <section>
       <label>Start date</label>
-      <input type="text" name="start_availability" placeholder="01/06/2016">
+      <input type="date" name="start_availability" placeholder="01/06/2016">
     </section>
 
     <section>
       <label>End date</label>
-      <input type="text" name="end_availability" placeholder="31/08/2016">
+      <input type="date" name="end_availability" placeholder="31/08/2016">
     </section>
 
     <button class="btn" type="submit">Submit</button>

--- a/spec/features/individual_request_page_spec.rb
+++ b/spec/features/individual_request_page_spec.rb
@@ -1,0 +1,50 @@
+feature 'Individual request page' do
+  let(:guest1) { User.create(name: 'Guest', username: 'Guest123', email: 'guest1@me.com', password: 1234, password_confirmation: 1234) }
+  let(:guest2) { User.create(name: 'Guest2', username: 'Guest2123', email: 'guest2@me.com', password: 1234, password_confirmation: 1234) }
+
+  let(:host1) { User.create(name: 'Host1', username: 'Host1', email: 'host1@me.com', password: 1234, password_confirmation: 1234) }
+  let(:host2) { User.create(name: 'Host2', username: 'Host2', email: 'host2@me.com', password: 1234, password_confirmation: 1234) }
+  let(:host3) { User.create(name: 'Host3', username: 'Host3', email: 'host3@me.com', password: 1234, password_confirmation: 1234) }
+
+  let(:space1) { Space.create(name: 'BigBen', description: 'Big bell in London', price: 250, user: host1, start_availability: '12/04/2016', end_availability: '30/09/2015') }
+  let(:space2) { Space.create(name: 'The Rizz', description: 'In paris. La vie!', price: 250, user: host2, start_availability: '12/04/2016', end_availability: '30/09/2015')}
+
+  let!(:booking) { Booking.create(space_id: space1.id, host_id: host1.id, guest_id: guest1.id, status: 'Pending', booking_start: '12/06/2016', booking_end: '16/06/2016', total_price: 250) }
+  let!(:booking2) { Booking.create(space_id: space2.id, host_id: host2.id, guest_id: guest1.id, status: 'Pending', booking_start: '12/05/2016', booking_end: '16/05/2016', total_price: 250) }
+  let!(:booking3) { Booking.create(space_id: space1.id, host_id: host1.id, guest_id: guest2.id, status: 'Pending', booking_start: '14/07/2016', booking_end: '16/07/2016', total_price: 250) }
+
+  before :each do
+    signin('Anne',1234)
+    visit 'requests'
+  end
+
+  feature 'Host' do
+    before :each do
+      signin(host1.email,1234)
+      visit('requests')
+    end
+
+    scenario 'should be able to click request for more detailed information' do
+      visit '/requests'
+      first('.detailed-view').click
+      expect(page).to have_content('Request for \'BigBen\'')
+      expect(page).to have_content('From: guest1@me.com')
+      expect(page).to have_content('Dates: 12/06/2016 to 16/06/2016')
+    end
+
+    scenario 'should include list of other requests for same space' do
+      visit '/requests'
+      first('.detailed-view').click
+      within(:css, '.other-requests') do
+        expect(page).not_to have_content('Dates: 12/06/2016 to 16/06/2016')
+        expect(page).to have_content('Other Requests for this Space')
+        expect(page).to have_content('Pending')
+        expect(page).to have_content('Dates: 14/07/2016 to 16/07/2016')
+      end
+    end
+
+    # scenario 'should be able to confirm or decline a reservation request' do
+    #
+    # end
+  end
+end

--- a/spec/features/individual_request_page_spec.rb
+++ b/spec/features/individual_request_page_spec.rb
@@ -43,8 +43,8 @@ feature 'Individual request page' do
       end
     end
 
-    # scenario 'should be able to confirm or decline a reservation request' do
-    #
-    # end
+    scenario 'should be able to confirm or decline a reservation request' do
+
+    end
   end
 end


### PR DESCRIPTION
Lots of style changes in addition to the introduction of an individual request page. After clicking on a request from the requests dashboard, a user will see a page with more information about that specific request, buttons to confirm or decline the request (if not already done), and a list of other requests for the same space. Each request page can be accessed at /bookings/:booking_id.
